### PR TITLE
Load only saved vocabulary when recognizing

### DIFF
--- a/recognize.py
+++ b/recognize.py
@@ -24,7 +24,7 @@ num_dim = 128      # latent dimension
 #
 
 # VCTK corpus input tensor ( with QueueRunner )
-data = VCTK()
+data = VCTK(vocabulary_loading=True)
 
 # vocabulary size
 voca_size = data.voca_size


### PR DESCRIPTION
Loading entire dataset for recognizing is not necessary and time consuming. 
Make recognize.py load saved vocabulary file when first training started.

P.S. I am not familiar with Python grammar. Although I had tried to follow the coding conventions of the editing file, there might be an inconsistency in the naming or else. So, please feel free to let me know the naming or something is wrong. :) 