### PR TITLE
detect file duration rather than it's size

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ As mentioned earlier, there is no language model, so there are some cases where 
 ## Pre-trained models
 
 You can transform a speech wave file to English text with the pre-trained model on the VCTK corpus. 
-Extract [the following zip file](https://drive.google.com/open?id=0B3ILZKxzcrUyVWwtT25FemZEZ1k) to the 'asset/train/ckpt/' directory.
+Extract [the following zip file](https://drive.google.com/open?id=0B3ILZKxzcrUyVWwtT25FemZEZ1k) to the 'asset/train' directory.
 
 ## Other resources
 

--- a/data.py
+++ b/data.py
@@ -89,7 +89,7 @@ class VCTK(object):
         # exclude extremely short wave files
         file_id, wav_file = [], []
         for i, w in zip(file_ids, wav_files):
-            if os.stat(w).st_size > 240000:  # at least 5 seconds
+            if librosa.core.get_duration(filename=w) > 5: #at least 5 seconds
                 file_id.append(i)
                 wav_file.append(w)
 

--- a/recognize.py
+++ b/recognize.py
@@ -99,7 +99,7 @@ with tf.Session() as sess:
 
     # restore parameters
     saver = tf.train.Saver()
-    saver.restore(sess, tf.train.latest_checkpoint('asset/train/ckpt'))
+    saver.restore(sess, tf.train.latest_checkpoint('asset/train'))
 
     # run session
     label = sess.run(y, feed_dict={x: mfcc})


### PR DESCRIPTION
While trying to use the project on downsampled (to 8kHz) VCTK corpus I run into errors because my files were smaller. I noticed, that you're checking file size, rather than it's duration, and since librosa was already included I've patched data.py to use it to detect file duration. 