### PR TITLE
changed checkpoints directory, to the one used by sugartensor by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ As mentioned earlier, there is no language model, so there are some cases where 
 ## Pre-trained models
 
 You can transform a speech wave file to English text with the pre-trained model on the VCTK corpus. 
-Extract [the following zip file](https://drive.google.com/open?id=0B3ILZKxzcrUyVWwtT25FemZEZ1k) to the 'asset/train/ckpt/' directory.
+Extract [the following zip file](https://drive.google.com/open?id=0B3ILZKxzcrUyVWwtT25FemZEZ1k) to the 'asset/train' directory.
 
 ## Other resources
 

--- a/recognize.py
+++ b/recognize.py
@@ -99,7 +99,7 @@ with tf.Session() as sess:
 
     # restore parameters
     saver = tf.train.Saver()
-    saver.restore(sess, tf.train.latest_checkpoint('asset/train/ckpt'))
+    saver.restore(sess, tf.train.latest_checkpoint('asset/train'))
 
     # run session
     label = sess.run(y, feed_dict={x: mfcc})


### PR DESCRIPTION
When trying to use recongize.py I've encountered an error due to mismatch between default checkpoints directory of sugartensor (asset/train) and the one specified in recognize.py (asset/train/ckpt), this pull request aims to fix that.