### PR TITLE
Fixed link of fast-wavenet in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ and the polyglot speech recognition model will be a good candidate to future wor
 ## Other resources
 
 1. [ibab's WaveNet(speech synthesis) tensorflow implementation](https://github.com/ibab/tensorflow-wavenet)
-1. [tomlepaine's Fast WaveNet(speech synthesis) tensorflow implementation](https://github.com/ibab/tensorflow-wavenet)
+1. [tomlepaine's Fast WaveNet(speech synthesis) tensorflow implementation](https://github.com/tomlepaine/fast-wavenet)
 
 ## Namju's other repositories
 


### PR DESCRIPTION
The link in README.md of fast-wavenet(by tomlepaine) should be:
https://github.com/tomlepaine/fast-wavenet
